### PR TITLE
Suggestion for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cifar2
 ### Propose
 
-SFU/CMPT419A3Q4 tune hyperparameters for training Cifar2
+SFU/CMPT419 Assignment3 Q4 tune hyperparameters for training Cifar2
 
 ### Learning Objective
 


### PR DESCRIPTION
Change "SFU/CMPT419A3Q4" to "SFU/CMPT419 Assignment3 Q4". The original expression reduces readability, and it is difficult to clearly identify the source of the code at once. And there is no division "419A3Q4" between each content, which is not friendly to other people who watch the code but are not students of this class, and it will look like some garbled code at first glance.